### PR TITLE
WIP SS4 compat, rewrite to DBField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,16 @@ sudo: false
 
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-
-env:
-  - DB=MYSQL CORE_RELEASE=3.2
-
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3
+      env: DB=MYSQL CORE_RELEASE=4
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
+      env: DB=PGSQL CORE_RELEASE=4
     - php: 7.0
+      env: DB=MYSQL CORE_RELEASE=4
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=4
 
 before_script:
   - composer self-update || true

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 	},
     "autoload": {
         "psr-4": {
-            "SilverStripe\\MultiValueField\\": "src/"
+            "SilverStripe\\MultiValueField\\": "src/",
+            "SilverStripe\\MultiValueField\\Tests\\": "tests/"
         }
     }
 }

--- a/tests/MultiValueFieldTest.php
+++ b/tests/MultiValueFieldTest.php
@@ -11,44 +11,76 @@ use SilverStripeAustralia\MultiValueField\Fields\MultiValueField;
  */
 class MultiValueFieldTest extends SapphireTest {
 
-	protected static $extra_dataobjects = array(
+    protected static $extra_dataobjects = array(
         MultiValueFieldTest_DataObject::class
-	);
+    );
 
-	public function testMultiValueField() {
-		$first = array('One', 'Two', 'Three');
+    public function testUpdate() {
+        $obj = new MultiValueFieldTest_DataObject();
+        $obj->MVField = ['One', 'Two'];
+        $obj->write();
 
-		$obj = new MultiValueFieldTest_DataObject();
-		$obj->MVField = $first;
-		$obj->write();
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $obj->MVField = ['Three'];
+        $obj->write();
 
-		$this->assertTrue($obj->isInDB());
-		$obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $this->assertEquals(['Three'], $obj->obj('MVField')->getValues());
+    }
 
-		$this->assertNotNull($obj->MVField);
-		$this->assertEquals($first, $obj->MVField->getValues());
+    public function testSetArrayAsProperty() {
+        $obj = new MultiValueFieldTest_DataObject();
+        $obj->MVField = ['One', 'Two'];
+        $obj->write();
 
-		$second = array('Four', 'Five');
-		$obj->MVField = $second;
-		$obj->write();
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $this->assertNotNull($obj->MVField);
+        $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
+    }
 
-		$this->assertEquals($second, $obj->MVField->getValues());
-	}
+    public function testSetSerialisedStringAsProperty() {
+        $obj = new MultiValueFieldTest_DataObject();
+        $obj->MVField = serialize(['One', 'Two']);
+        $obj->write();
 
-	public function testIsChanged() {
-		$field = new MultiValueField();
-		$this->assertFalse($field->isChanged());
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $this->assertNotNull($obj->MVField);
+        $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
+    }
 
-		$field->setValue(array(1, 2, 3));
-		$this->assertTrue($field->isChanged());
+    public function testSetSerialisedStringWithSetValue() {
+        $obj = new MultiValueFieldTest_DataObject();
+        $obj->obj('MVField')->setValue(serialize(['One', 'Two']));
+        $obj->write();
 
-		$field = new MultiValueField();
-		$field->setValue(array(1, 2, 3), null, false);
-		$this->assertFalse($field->isChanged());
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $this->assertNotNull($obj->MVField);
+        $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
+    }
 
-		$field = DBField::create_field('MultiValueField', array(1, 2, 3));
-		$field->setValue(null);
-		$this->assertTrue($field->isChanged());
-	}
+    public function testSetArrayWithSetValue() {
+        $obj = new MultiValueFieldTest_DataObject();
+        $obj->obj('MVField')->setValue(['One', 'Two']);
+        $obj->write();
+
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $this->assertNotNull($obj->MVField);
+        $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
+    }
+
+    public function testIsChanged() {
+        $field = new MultiValueField();
+        $this->assertFalse($field->isChanged());
+
+        $field->setValue(['One', 'Two']);
+        $this->assertTrue($field->isChanged());
+
+        $field = new MultiValueField();
+        $field->setValue(['One', 'Two'], null, false);
+        $this->assertFalse($field->isChanged());
+
+        $field = DBField::create_field('MultiValueField', ['One', 'Two']);
+        $field->setValue(null);
+        $this->assertTrue($field->isChanged());
+    }
 
 }

--- a/tests/MultiValueFieldTest.php
+++ b/tests/MultiValueFieldTest.php
@@ -1,11 +1,18 @@
 <?php
+namespace SilverStripeAustralia\MultiValueField\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripeAustralia\MultiValueField\Fields\MultiValueField;
+
+
 /**
  * @author Marcus Nyeholt <marcus@silverstripe.com.au>
  */
 class MultiValueFieldTest extends SapphireTest {
 
-	protected $extraDataObjects = array(
-		'MultiValueFieldTest_DataObject'
+	protected static $extra_dataobjects = array(
+        MultiValueFieldTest_DataObject::class
 	);
 
 	public function testMultiValueField() {
@@ -16,7 +23,7 @@ class MultiValueFieldTest extends SapphireTest {
 		$obj->write();
 
 		$this->assertTrue($obj->isInDB());
-		$obj = DataObject::get_by_id('MultiValueFieldTest_DataObject', $obj->ID);
+		$obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
 
 		$this->assertNotNull($obj->MVField);
 		$this->assertEquals($first, $obj->MVField->getValues());
@@ -43,16 +50,5 @@ class MultiValueFieldTest extends SapphireTest {
 		$field->setValue(null);
 		$this->assertTrue($field->isChanged());
 	}
-
-}
-
-/**
- * @ignore
- */
-class MultiValueFieldTest_DataObject extends DataObject implements TestOnly {
-
-	private static $db = array(
-		'MVField' => 'MultiValueField'
-	);
 
 }

--- a/tests/MultiValueFieldTest_DataObject.php
+++ b/tests/MultiValueFieldTest_DataObject.php
@@ -1,0 +1,18 @@
+<?php
+namespace SilverStripeAustralia\MultiValueField\Tests;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * @ignore
+ */
+class MultiValueFieldTest_DataObject extends DataObject implements TestOnly {
+
+    private static $db = array(
+        'MVField' => 'MultiValueField'
+    );
+
+    private static $table_name = 'MultiValueFieldTest_DataObject';
+
+}


### PR DESCRIPTION
This started out as an innocent "fix tests for 4.x" task: The master branch of this module (3.x release line) has been made 4.x compatible a while ago, but the test config didn't reflect that

But it turns out the field is quite broken with the SS4 ORM:
The field is not a “composite” field, since it only has one database column.
The DBComposite API has changed a bit in SS4, which causes the field to break in weird ways
since it has overloaded so much of the underlying core functionality. For example,
the field never gets written since it doesn’t set MyFieldValue, and
DataObject->prepareManipulationTable() skips MyField because it’s not a database column.
Rather than fixing these quirks, it’s much easier to rewrite the field as a DBText.

TODO:
- Document db column migration path (from MyFieldValue to MyField)
- Change from serialise() to json_encode() for security reasons

@sanderha @wernerkrauss @digitall-it @brasileric Anybody keen to review and help get this over the line?