### PR TITLE
Support other tags than input and pass content when needed

### DIFF
--- a/code/fields/MultiValueTextField.php
+++ b/code/fields/MultiValueTextField.php
@@ -59,8 +59,9 @@ class MultiValueTextField extends FormField {
 	}
 
 	public function createInput($attributes, $value = null) {
-        $attributes['value'] = $value;
-		return self::create_tag($this->tag, $attributes);
+		$attributes['value'] = $value;
+		$content = (($this->tag !== 'input') ? $value : null);
+		return self::create_tag($this->tag, $attributes, $content);
 	}
 
 	public function performReadonlyTransformation() {


### PR DESCRIPTION
When the tag is not an input tag (e.g. a textarea), the create_tag function can't get the value from the $attribute array and expects it as a 3rd parameter. 