### PR TITLE
Ensure $value is defined

### DIFF
--- a/code/fields/MultiValueCheckboxField.php
+++ b/code/fields/MultiValueCheckboxField.php
@@ -118,6 +118,8 @@ class MultiValueCheckboxField extends CheckboxSetField {
 		// See CheckboxSetField::getOptions from here on
         $odd = false;
 		foreach ($source as $index => $item) {
+            $value = '';
+
             // Ensure $title is cast for template
             if ($item instanceof DataObject) {
                 $value = $item->ID;


### PR DESCRIPTION
Fix `Undefined variable: value`  error when using MultiValueCheckboxField with a list of items that are not DataObjects