### PR TITLE
Ensure value works correctly within MultiValueCheckboxField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # See https://github.com/silverstripe/silverstripe-travis-support for setup details
 
-sudo: false
+dist: trusty
 
 language: php
 

--- a/code/fields/MultiValueCheckboxField.php
+++ b/code/fields/MultiValueCheckboxField.php
@@ -123,8 +123,10 @@ class MultiValueCheckboxField extends CheckboxSetField {
                 $value = $item->ID;
                 $title = $item->obj('Title');
             } elseif ($item instanceof DBField) {
+                $value = $index;
                 $title = $item;
             } else {
+                $value = $index;
                 $title = DBField::create_field('Text', $item);
             }
 


### PR DESCRIPTION
When options for MultiValueCheckboxField are not instances of DataObject, the `$value` wasn't populated correctly, failing to populate the ID and extra class.