### PR TITLE
Allow a placeholder on the key/value input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ In this case, `$Value` is a Varchar object, so you can call all relevant string 
 
 Note that to have the `$Key` value available as something other than an integer, use the `KeyValueField` field type to populate the field.
 
+You can set the key and value placeholder values of the KeyValueField in your field like this:
+```
+$kvf = KeyValueField::create(
+    'MultiChoiceAnswer',
+    'Multiple Choice Answers'
+);
+$kvf->setValueFieldPlaceholder('Value');
+$kvf->setKeyFieldPlaceholder('Label');
+```
+
 
 ## Maintainer Contacts
 

--- a/src/Fields/KeyValueField.php
+++ b/src/Fields/KeyValueField.php
@@ -20,6 +20,57 @@ class KeyValueField extends MultiValueTextField
     protected $sourceKeys;
     protected $sourceValues;
 
+    /**
+     * keyFieldPlaceholder
+     *
+     * @var string
+     */
+    protected $keyFieldPlaceholder;
+
+    /**
+     * valueFieldPlaceholder
+     *
+     * @var string
+     */
+    protected $valueFieldPlaceholder;
+
+
+    /**
+     * Returns the KeyPlaceholder value
+     **/
+    public function getKeyFieldPlaceholder()
+    {
+        return $this->keyFieldPlaceholder;
+    }
+
+    /**
+     * Sets the KeyPlaceholder value
+     **/
+    public function setKeyFieldPlaceholder($value)
+    {
+        $this->keyFieldPlaceholder = $value;
+        return $this;
+    }
+
+    /**
+     * Returns the ValuePlaceholder value
+     **/
+    public function getValueFieldPlaceholder()
+    {
+        return $this->valueFieldPlaceholder;
+    }
+
+    /**
+     * Sets the ValuePlaceholder value
+     **/
+    public function setValueFieldPlaceholder($value)
+    {
+        $this->valueFieldPlaceholder = $value;
+        return $this;
+    }
+
+
+
     public function __construct($name, $title = null, $sourceKeys = [], $sourceValues = [], $value = null)
     {
         parent::__construct($name, ($title === null) ? $name : $title, $value);
@@ -54,8 +105,8 @@ class KeyValueField extends MultiValueTextField
                     $valField        = HTML::createTag('span', $fieldAttr, Convert::raw2xml($v));
                     $fields[]        = $keyField.$valField;
                 } else {
-                    $keyField = $this->createSelectList($i, $nameKey, $this->sourceKeys, $i);
-                    $valField = $this->createSelectList($i, $nameVal, $this->sourceValues, $v);
+                    $keyField = $this->createSelectList($i, $nameKey, $this->sourceKeys, $i, $this->getKeyFieldPlaceholder());
+                    $valField = $this->createSelectList($i, $nameVal, $this->sourceValues, $v, $this->getValueFieldPlaceholder());
                     $fields[] = $keyField.' '.$valField;
                 }
             }
@@ -64,8 +115,8 @@ class KeyValueField extends MultiValueTextField
         }
 
         if (!$this->readonly) {
-            $keyField = $this->createSelectList('new', $nameKey, $this->sourceKeys);
-            $valField = $this->createSelectList('new', $nameVal, $this->sourceValues);
+            $keyField = $this->createSelectList('new', $nameKey, $this->sourceKeys, '', $this->getKeyFieldPlaceholder());
+            $valField = $this->createSelectList('new', $nameVal, $this->sourceValues, '', $this->getValueFieldPlaceholder());
             $fields[] = $keyField.' '.$valField;
 //          $fields[] = $this->createSelectList('new', $name, $this->source);
         }
@@ -74,7 +125,7 @@ class KeyValueField extends MultiValueTextField
                 $fields).'</li></ul>';
     }
 
-    protected function createSelectList($number, $name, $values, $selected = '')
+    protected function createSelectList($number, $name, $values, $selected = '', $placeholder = '')
     {
         $options = HTML::createTag(
                 'option',
@@ -111,6 +162,7 @@ class KeyValueField extends MultiValueTextField
                 'name' => $name,
                 'tabindex' => $this->getAttribute('tabindex'),
                 'type' => 'text',
+                'placeholder' => $placeholder,
             ];
 
             if ($this->disabled) $attrs['disabled'] = 'disabled';

--- a/tests/KeyValueFieldTest.php
+++ b/tests/KeyValueFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symbiote\KeyValueField\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\MultiValueField\Fields\KeyValueField;
+
+class KeyValueFieldTest extends Sapphiretest
+{
+    public function testKeyFieldPlaceholder()
+    {
+        $field = new KeyValueField('test');
+        $this->assertEmpty($field->getKeyFieldPlaceholder());
+        $field->setKeyFieldPlaceholder('test-placeholder');
+        $this->assertSame('test-placeholder', $field->getKeyFieldPlaceholder());
+    }
+
+    public function testValueFieldPlaceholder()
+    {
+        $field = new KeyValueField('test');
+        $this->assertEmpty($field->getValueFieldPlaceholder());
+        $field->setValueFieldPlaceholder('test-placeholder');
+        $this->assertSame('test-placeholder', $field->getValueFieldPlaceholder());
+    }
+
+    public function testFieldContainsPlaceholder()
+    {
+        $field = new KeyValueField('test');
+        $field->setKeyFieldPlaceholder('Key Placeholder');
+        $field->setValueFieldPlaceholder('Value Placeholder');
+        $html = $field->Field();
+        $this->assertContains('placeholder="Key Placeholder"', $html);
+        $this->assertContains('placeholder="Value Placeholder"', $html);
+    }
+}


### PR DESCRIPTION
We have users wondering what the left and right columns represent. This feature allows a developer to set the placeholder text for either of the two input fields. 

All feedback welcome!

---

Merge checklist:

- [x] rebase/retarget to the next minor, so 5 instead of master
- [x] merge conflicts need to be sorted (it's on .travis.yml so feel free to ask questions in unsure what needs to be done here)
- [x] requires unit tests
- [x] travis build need to be green
