### PR TITLE
Remove PostgreSQL tests from travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 
 services:
   - mysql
-  - postgresql
 
 dist: xenial
 
@@ -16,8 +15,6 @@ matrix:
   include:
     - php: 5.6
       env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 5.6
-      env: DB=PGSQL PHPUNIT_TEST=1
     - php: 7.0
       env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
@@ -32,7 +29,6 @@ before_script:
   - phpenv config-rm xdebug.ini
   - composer validate
   - composer require --no-update silverstripe/recipe-cms:^4
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:


### PR DESCRIPTION
Follow up on https://github.com/symbiote/silverstripe-multivaluefield/pull/63

It looks like PostgreSQL might have never worked for SilverStripe4. At least we never ran the tests for it. This PR removes those tests from travis for the time being. If we decide to explicitly support PostgreSQL, we should fix it first and then return the tests back afterwards.

An issue for PostgreSQL support is at #67.